### PR TITLE
wildmatch: take option arguments for configuration

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -8,6 +8,9 @@ import (
 	"unicode/utf8"
 )
 
+// opt is an option type for configuring a new Wildmatch instance.
+type opt func(w *Wildmatch)
+
 // Wildmatch implements pattern matching against filepaths using the format
 // described in the package documentation.
 //
@@ -24,14 +27,18 @@ type Wildmatch struct {
 //
 // If the pattern is malformed, for instance, it has an unclosed character
 // group, escape sequence, or character class, NewWildmatch will panic().
-func NewWildmatch(p string) *Wildmatch {
-	p = filepath.Clean(p)
-
-	dirs := strings.Split(p, string(filepath.Separator))
-	return &Wildmatch{
-		ts: parseTokens(dirs),
-		p:  p,
+func NewWildmatch(p string, opts ...opt) *Wildmatch {
+	w := &Wildmatch{
+		p: filepath.Clean(p),
 	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	w.ts = parseTokens(strings.Split(w.p, string(filepath.Separator)))
+
+	return w
 }
 
 // parseTokens parses a separated list of patterns into a sequence of

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -8,6 +8,7 @@ type Case struct {
 	Pattern string
 	Subject string
 	Match   bool
+	Opts    []opt
 }
 
 func (c *Case) Assert(t *testing.T) {
@@ -19,7 +20,7 @@ func (c *Case) Assert(t *testing.T) {
 		}
 	}()
 
-	p := NewWildmatch(c.Pattern)
+	p := NewWildmatch(c.Pattern, c.Opts...)
 	if p.Match(c.Subject) != c.Match {
 		if c.Match {
 			t.Errorf("expected match: %s, %s", c.Pattern, c.Subject)


### PR DESCRIPTION
This pull request implements support for the option function pattern, as described by Cheney [here][1].

In this patch, there are no implementations of the option function, but they will prove useful for future endeavors. For example:

1. The next patch will introduce support for the `WM_PATHNAME` option, which will be exposed via the package API as an option.
2. The subsequent patch with introduce support for the `WM_CASEFOLD` option, which will also be exposed via the package API as an option.

##

[1]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis