### PR TITLE
wildmatch: support the WM_PATHNAME option

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -165,11 +165,17 @@ func (d *doubleStar) Consume(path []string, isDir bool) ([]string, bool) {
 
 	// Otherwise, backtrack through the remainder of the path components,
 	// trying to find the maximal match.
-	for i := len(path); i > 0; i-- {
-		rest, ok := d.Until.Consume(path[i:], false)
-		if ok {
-			// As soon as a match has been found, return it.
-			return rest, ok
+	for i := len(path) - 1; i >= 0; i-- {
+		for j := len(path[i]) - 1; j >= 0; j-- {
+			x := make([]string, len(path)-i)
+			copy(x, path[i:])
+			x[0] = x[0][j:]
+
+			rest, ok := d.Until.Consume(x, false)
+			if ok {
+				// As soon as a match has been found, return it.
+				return rest, ok
+			}
 		}
 	}
 

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -169,7 +169,7 @@ var Cases = []*Case{
 	{
 		Pattern: `**/foo`,
 		Subject: `foo`,
-		Match:   false,
+		Match:   true,
 	},
 	{
 		Pattern: `**/foo`,

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -232,6 +232,17 @@ var Cases = []*Case{
 		Match:   true,
 	},
 	{
+		Pattern: `*.txt`,
+		Subject: `foo/bar/baz.txt`,
+		Match:   false,
+	},
+	{
+		Pattern: `*.txt`,
+		Subject: `foo/bar/baz.txt`,
+		Opts:    []opt{MatchPathname},
+		Match:   true,
+	},
+	{
 		Pattern: `a[c-c]st`,
 		Subject: `acrt`,
 		Match:   false,


### PR DESCRIPTION
This pull request implements support for the `WM_PATHNAME` option, as used in Git's `wildmatch.c`.

I could not find documentation on `WM_PATHNAME` in upstream Git, so what follows is my best understanding of its functionality from reading the code:

> ```go
> // MatchPathname allows for matches "anywhere" in the pathname, by a de-facto
> // replacement of the "*" operator into "**/".
> //
> // For instance, without MatchPathname, the pattern "*.txt" will match "x.txt",
> // but not "y/z.txt". With MatchPathname enabled, the above pattern will match
> // both of the aforementioned pathnames (i.e., the pattern will behave
> // equivalently to **/*.txt").
> ```

In other terms, allow the `*` operator to match across subdirectories.

While working on this patch, uncovered an issue with the `**` double-star implementation of the `Token` interface (since under the above mode, `*`'s are translated into `**`'s). The bug is as follows: previously the `**` tried to match whole path components, when it should have been doing so incrementally.

For example, to match against the pattern `foo/bar/baz/woot.txt` (for `*.txt` ~> `**/.txt`), the previous set of greedy matches it tried was:

- `foo/bar/baz/woot.txt` (fail)
- `foo/bar/baz` (fail)
- `foo/bar` (fail)
- `foo` (fail)
- `` (fail)

Whereas it should be trying the following:

- `foo/bar/baz/woot.txt` (fail)
- `foo/bar/baz/oot.txt` (fail)
- `foo/bar/baz/ot.txt` (fail)
- `foo/bar/baz/t.txt` (fail)
- `foo/bar/baz/.txt` (OK)

In more abstract terms, the `**` operator should attempt to match as much of the whole directory structure as possible, including partial paths.

##