### PR TITLE
wildmatch: support the WM_CASEFOLD option

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -28,6 +28,11 @@ var (
 	CaseFold opt = func(w *Wildmatch) {
 		w.caseFold = true
 	}
+
+	// SystemCase either folds or does not fold filepaths and patterns,
+	// according to whether or not the operating system on which Wildmatch
+	// runs supports case sensitive files or not.
+	SystemCase opt
 )
 
 // Wildmatch implements pattern matching against filepaths using the format

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -11,16 +11,18 @@ import (
 // opt is an option type for configuring a new Wildmatch instance.
 type opt func(w *Wildmatch)
 
-// MatchPathname allows for matches "anywhere" in the pathname, by a de-facto
-// replacement of the "*" operator into "**/".
-//
-// For instance, without MatchPathname, the pattern "*.txt" will match "x.txt",
-// but not "y/z.txt". With MatchPathname enabled, the above pattern will match
-// both of the aforementioned pathnames (i.e., the pattern will behave
-// equivalently to **/*.txt").
-var MatchPathname opt = func(w *Wildmatch) {
-	w.matchPathname = true
-}
+var (
+	// MatchPathname allows for matches "anywhere" in the pathname, by a
+	// de-facto replacement of the "*" operator into "**/".
+	//
+	// For instance, without MatchPathname, the pattern "*.txt" will match
+	// "x.txt", but not "y/z.txt". With MatchPathname enabled, the above
+	// pattern will match both of the aforementioned pathnames (i.e., the
+	// pattern will behave equivalently to **/*.txt").
+	MatchPathname opt = func(w *Wildmatch) {
+		w.matchPathname = true
+	}
+)
 
 // Wildmatch implements pattern matching against filepaths using the format
 // described in the package documentation.

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -22,6 +22,12 @@ var (
 	MatchPathname opt = func(w *Wildmatch) {
 		w.matchPathname = true
 	}
+
+	// CaseFold allows the receiving Wildmatch to match paths with
+	// different case structuring as in the pattern.
+	CaseFold opt = func(w *Wildmatch) {
+		w.caseFold = true
+	}
 )
 
 // Wildmatch implements pattern matching against filepaths using the format

--- a/wildmatch_linux.go
+++ b/wildmatch_linux.go
@@ -1,0 +1,7 @@
+// +build linux
+
+package wildmatch
+
+func init() {
+	SystemCase = CaseFold
+}

--- a/wildmatch_notlinux.go
+++ b/wildmatch_notlinux.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package wildmatch
+
+func init() {
+	SystemCase = func(w *Wildmatch) {}
+}

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -587,6 +587,17 @@ var Cases = []*Case{
 		Subject: `abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz`,
 		Match:   false,
 	},
+	{
+		Pattern: `foo`,
+		Subject: `FOO`,
+		Match:   false,
+	},
+	{
+		Pattern: `foo`,
+		Subject: `FOO`,
+		Opts:    []opt{CaseFold},
+		Match:   true,
+	},
 }
 
 func TestWildmatch(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for the `WM_CASEFOLD` option, as requested by @larsxschneider in https://github.com/git-lfs/wildmatch/issues/1.

Closes: https://github.com/git-lfs/wildmatch/issues/1.

##

/cc @larsxschneider 