### PR TITLE
wildmatch: ensure given patterns are POSIX-compliant

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -69,6 +69,37 @@ const (
 	escapes = "\\[]*?"
 )
 
+// slashEscape converts paths "p" to POSIX-compliant path, independent of which
+// escape character the host machine uses.
+//
+// slashEscape resepcts escapable sequences, and thus will not transform
+// `foo\*bar` to `foo/*bar` on non-Windows operating systems.
+func slashEscape(p string) string {
+	var pp string
+
+	for i := 0; i < len(p); {
+		c := p[i]
+
+		switch c {
+		case '\\':
+			if i+1 < len(p) && escapable(p[i+1]) {
+				pp += `\`
+				pp += string(p[i+1])
+
+				i += 2
+			} else {
+				pp += `/`
+				i += 1
+			}
+		default:
+			pp += string(c)
+			i += 1
+		}
+	}
+
+	return pp
+}
+
 // escapable returns whether the given "c" is escapable.
 func escapable(c byte) bool {
 	return strings.IndexByte(escapes, c) > -1

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -48,7 +48,7 @@ type Wildmatch struct {
 // If the pattern is malformed, for instance, it has an unclosed character
 // group, escape sequence, or character class, NewWildmatch will panic().
 func NewWildmatch(p string, opts ...opt) *Wildmatch {
-	w := &Wildmatch{p: p}
+	w := &Wildmatch{p: slashEscape(p)}
 
 	for _, opt := range opts {
 		opt(w)

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -604,3 +604,34 @@ func TestWildmatch(t *testing.T) {
 		c.Assert(t)
 	}
 }
+
+type SlashCase struct {
+	Given  string
+	Expect string
+}
+
+func (c *SlashCase) Assert(t *testing.T) {
+	got := slashEscape(c.Given)
+
+	if c.Expect != got {
+		t.Errorf("wildmatch: expected slashEscape(\"%s\") -> %s, got: %s",
+			c.Given,
+			c.Expect,
+			got,
+		)
+	}
+}
+
+func TestSlashEscape(t *testing.T) {
+	for _, c := range []*SlashCase{
+		{Given: ``, Expect: ``},
+		{Given: `foo/bar`, Expect: `foo/bar`},
+		{Given: `foo\bar`, Expect: `foo/bar`},
+		{Given: `foo\*bar`, Expect: `foo\*bar`},
+		{Given: `foo\?bar`, Expect: `foo\?bar`},
+		{Given: `foo\[bar`, Expect: `foo\[bar`},
+		{Given: `foo\]bar`, Expect: `foo\]bar`},
+	} {
+		c.Assert(t)
+	}
+}

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -327,11 +327,6 @@ var Cases = []*Case{
 		Match:   true,
 	},
 	{
-		Pattern: `\a\b\c`,
-		Subject: `abc`,
-		Match:   true,
-	},
-	{
 		Pattern: `''`,
 		Subject: `foo`,
 		Match:   false,
@@ -560,16 +555,6 @@ var Cases = []*Case{
 		Pattern: `[,-.]`,
 		Subject: `-.]`,
 		Match:   false,
-	},
-	{
-		Pattern: `[\1-\3]`,
-		Subject: `2`,
-		Match:   true,
-	},
-	{
-		Pattern: `[\1-\3]`,
-		Subject: `3`,
-		Match:   true,
 	},
 	{
 		Pattern: `-*-*-*-*-*-*-12-*-*-*-m-*-*-*`,


### PR DESCRIPTION
This pull request introduces `slashEscape`, which ensures that given paths are (pseudo) POSIX-compliant, while preserving the meaningfulness of escape sequences.

Wildmatch expects to perform pattern matching operations on POSIX-compliant paths (and mingw converts automatically [[1]](www.mingw.org/wiki/Posix_path_conversion)), but it is possible that the Windows command prompt does not do this.

To ensure correctness, convert to POSIX ourselves.

This pull request also removes three test cases that have behavior defined by the platform on which they are run. For instance, consider the test `\a\b\c`, which indicates `a/b/c` (in POSIX) on Windows, but on macOS is three invalid escape sequences. The behavior for these cases should be left undefined.

##