### PR TITLE
wildmatch: re-introduce WM_PATHNAME

### DIFF
--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -4,6 +4,26 @@ import (
 	"testing"
 )
 
+type PathnameCase struct {
+	Given  string
+	Expect string
+}
+
+func (c *PathnameCase) Assert(t *testing.T) {
+	if got := pathname(c.Given); got != c.Expect {
+		t.Errorf("pathname: expected %s, got %s", c.Expect, got)
+	}
+}
+
+func TestPathname(t *testing.T) {
+	for _, c := range []*PathnameCase{
+		{Given: "*.txt", Expect: "**/*.txt"},
+		{Given: "foo*.txt", Expect: "foo/**/*.txt"},
+	} {
+		c.Assert(t)
+	}
+}
+
 type Case struct {
 	Pattern string
 	Subject string


### PR DESCRIPTION
This pull request re-introduces the WM_PATHNAME option from Git's wildmatch.c, which treats '*' as able to match across directory boundaries, as if all `*` were re-written as `**/*`'s.

This option is already somewhat used in Git LFS, when translating from filepathfilter-style path matches to .gitattributes style matches in:

https://github.com/git-lfs/git-lfs/blob/5e601f8aa040e7e8c998c2c853dda844fa156789/filepathfilter/filepathfilter.go#L102

While implementing a .gitattributes parser over the gitobj package, I found it useful to have this option to translate patterns like `*.dat` into patterns like `**/*.dat` such that they could be used to match children at arbitrary depth. 

##

/cc @git-lfs/core 