### PR TITLE
wildmatch: teach Basename to match against basename only

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -2,6 +2,7 @@ package wildmatch
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -11,6 +12,13 @@ import (
 type opt func(w *Wildmatch)
 
 var (
+	// Basename allows the receiving Wildmatch to match paths where the
+	// pattern matches only the basename of the path. If the given pattern
+	// contains directory separators, the entire path is matched.
+	Basename opt = func(w *Wildmatch) {
+		w.basename = true
+	}
+
 	// CaseFold allows the receiving Wildmatch to match paths with
 	// different case structuring as in the pattern.
 	CaseFold opt = func(w *Wildmatch) {
@@ -37,6 +45,10 @@ type Wildmatch struct {
 	// p is the raw pattern used to derive the token set.
 	p string
 
+	// basename indicates that this Wildmatch instance matches basenames
+	// when possible (i.e., when there are no directory separators in the
+	// pattern).
+	basename bool
 	// caseFold allows the instance Wildmatch to match patterns with the
 	// same character but different case structures.
 	caseFold bool
@@ -59,7 +71,11 @@ func NewWildmatch(p string, opts ...opt) *Wildmatch {
 		w.p = strings.ToLower(w.p)
 	}
 
-	w.ts = parseTokens(strings.Split(w.p, string(sep)))
+	parts := strings.Split(w.p, string(sep))
+	if len(parts) > 1 {
+		w.basename = false
+	}
+	w.ts = parseTokens(parts)
 
 	return w
 }
@@ -164,6 +180,12 @@ func (w *Wildmatch) Match(t string) bool {
 // returns a slice of remaining directory paths, and whether or not there was a
 // disagreement while matching.
 func (w *Wildmatch) consume(t string) ([]string, bool) {
+	if w.basename {
+		// If the receiving Wildmatch has basename set, the pattern
+		// matches only the basename of the given "t".
+		t = filepath.Base(t)
+	}
+
 	if w.caseFold {
 		// If the receiving Wildmatch is case insensitive, the pattern
 		// "w.p" will be lower-case.

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -13,8 +13,11 @@ type opt func(w *Wildmatch)
 
 var (
 	// Basename allows the receiving Wildmatch to match paths where the
-	// pattern matches only the basename of the path. If the given pattern
-	// contains directory separators, the entire path is matched.
+	// pattern matches only the basename of the path when the pattern does
+	// not contain directory separators.
+	//
+	// If the pattern contains directory separators, or if this option is
+	// not given, the entire path will be matched.
 	Basename opt = func(w *Wildmatch) {
 		w.basename = true
 	}

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -597,6 +597,35 @@ var Cases = []*Case{
 		Subject: `foo-a.txt`,
 		Match:   false,
 	},
+	{
+		Pattern: `*.txt`,
+		Subject: `path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/file.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `outside/of/path/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   false,
+	},
+	{
+		Pattern: `path/to/*.txt`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Opts:    []opt{Basename},
+		Match:   false,
+	},
 }
 
 func TestWildmatch(t *testing.T) {

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -599,6 +599,12 @@ var Cases = []*Case{
 	},
 	{
 		Pattern: `*.txt`,
+		Subject: `file.txt`,
+		Opts:    []opt{Basename},
+		Match:   true,
+	},
+	{
+		Pattern: `*.txt`,
 		Subject: `path/to/file.txt`,
 		Opts:    []opt{Basename},
 		Match:   true,


### PR DESCRIPTION
In Git's attr.c, patterns found in a repository's .gitattributes
file(s) are matched on basename alone if and only if the pattern
contains no directory separators [1], [2].

This behavior allows a line such as:

    *.txt filter=lfs -text

in the repository's root .gitattributes (or .git/info/attributes) to
apply the filter=lfs and text=false attributes to a.txt, and
/path/to/a.txt. In general terms, this treats patterns as having a
prefixed `**/` in this case.

To simulate this behavior, we introduce the wildmatch.Basename
option to truncate incoming paths to their basename (using
filepath.Base from package path/filepath) if and only if the given
pattern contains only 1 ``split'', i.e., does not contain directory
separators.

For instance, given the wildmatch.Basename option, the following
patterns match:

  - *.txt matches foo.txt
  - *.txt matches foo/bar.txt
  - foo/*.txt matches foo/bar.txt
  - foo/*.txt does not match baz/foo/bar.txt
  - foo/*.txt does not match foo/bar/baz/woot.txt

This option suits a tree-like representation of a repository's
.gitattribute file(s) nicely, by giving wildmatch.Basename, we mirror
the correct behavior for paths relative to the directory in which they
are expressed in a .gitattributes file.

[1]: https://github.com/git/git/blob/v2.18.0/attr.c#L1005-L1010
[2]: https://github.com/git/git/blob/v2.18.0/dir.c#L608-L613

## 

/cc @git-lfs/core 