### PR TITLE
Fix case folding defaults

### DIFF
--- a/wildmatch_casefold.go
+++ b/wildmatch_casefold.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build windows darwin
 
 package wildmatch
 

--- a/wildmatch_nocasefold.go
+++ b/wildmatch_nocasefold.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build !windows,!darwin
 
 package wildmatch
 

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -1,6 +1,7 @@
 package wildmatch
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -674,5 +675,16 @@ func TestSlashEscape(t *testing.T) {
 		{Given: `foo\#bar`, Expect: `foo\#bar`},
 	} {
 		c.Assert(t)
+	}
+}
+
+func TestCaseFold(t *testing.T) {
+	m := NewWildmatch("*.bin", SystemCase)
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		if !m.Match("UPCASE.BIN") {
+			t.Errorf("wildmatch: expected system case to be folding")
+		}
+	} else if m.Match("UPCASE.BIN") {
+		t.Errorf("wildmatch: expected system case to be non-folding")
 	}
 }


### PR DESCRIPTION
This series addresses two different issues with case folding defaults.  First, we fix the issue that the defaults were swapped: Windows and macOS were set to be case sensitive, and Linux was set to be case insensitive.

Secondly, we fix the issue that we didn't consider non-Linux, non-macOS Unices at all; now, we default to case sensitive mode and explicitly single out Windows and macOS, assuming that all remaining platforms are Unix, or at least case sensitive (which as of this writing, appears to be true for all Go platforms that have a file system).