### PR TITLE
Add conditions to check for ending directories

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -133,6 +133,9 @@ func parseTokens(dirs []string) []token {
 
 	switch dirs[0] {
 	case "":
+		if len(dirs) == 1 {
+			return []token{&component{fns: []componentFn{substring("")}}}
+		}
 		return parseTokens(dirs[1:])
 	case "**":
 		rest := parseTokens(dirs[1:])
@@ -260,6 +263,10 @@ type doubleStar struct {
 
 // Consume implements token.Consume as above.
 func (d *doubleStar) Consume(path []string, isDir bool) ([]string, bool) {
+	if len(path) == 0 {
+		return path, false
+	}
+
 	// If there are no remaining tokens to match, allow matching the entire
 	// path.
 	if d.Until == nil {

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -28,6 +28,12 @@ var (
 		w.caseFold = true
 	}
 
+	// GitAttributes augments the functionality of the matching algorithm
+	// to match behavior of git when working with .gitattributes files.
+	GitAttributes opt = func(w *Wildmatch) {
+		w.gitattributes = true
+	}
+
 	// SystemCase either folds or does not fold filepaths and patterns,
 	// according to whether or not the operating system on which Wildmatch
 	// runs supports case sensitive files or not.
@@ -55,6 +61,15 @@ type Wildmatch struct {
 	// caseFold allows the instance Wildmatch to match patterns with the
 	// same character but different case structures.
 	caseFold bool
+
+	// gitattributes flag indicates that logic specific to the .gitattributes file
+	// should be used. The two main differences are that negative expressions are
+	// not allowed and directories are not matched.
+	gitattributes bool
+}
+
+type MatchOpts struct {
+	IsDirectory bool
 }
 
 // NewWildmatch constructs a new Wildmatch instance which matches filepaths
@@ -138,6 +153,7 @@ func parseTokens(dirs []string) []token {
 		}
 		return parseTokens(dirs[1:])
 	case "**":
+
 		rest := parseTokens(dirs[1:])
 		if len(rest) == 0 {
 			// If there are no remaining tokens, return a lone
@@ -175,7 +191,15 @@ func nonEmpty(all []string) (ne []string) {
 // Match returns true if and only if the pattern matched by the receiving
 // Wildmatch matches the entire filepath "t".
 func (w *Wildmatch) Match(t string) bool {
-	dirs, ok := w.consume(t)
+	dirs, ok := w.consume(t, MatchOpts{})
+	if !ok {
+		return false
+	}
+	return len(dirs) == 0
+}
+
+func (w *Wildmatch) MatchWithOpts(t string, opt MatchOpts) bool {
+	dirs, ok := w.consume(t, opt)
 	if !ok {
 		return false
 	}
@@ -185,7 +209,7 @@ func (w *Wildmatch) Match(t string) bool {
 // consume performs the inner match of "t" against the receiver's pattern, and
 // returns a slice of remaining directory paths, and whether or not there was a
 // disagreement while matching.
-func (w *Wildmatch) consume(t string) ([]string, bool) {
+func (w *Wildmatch) consume(t string, opt MatchOpts) ([]string, bool) {
 	if w.basename {
 		// If the receiving Wildmatch has basename set, the pattern
 		// matches only the basename of the given "t".
@@ -200,8 +224,24 @@ func (w *Wildmatch) consume(t string) ([]string, bool) {
 		t = strings.ToLower(t)
 	}
 
+	var isDir bool
+	if opt.IsDirectory {
+		isDir = true
+		// Standardize the formation of subject string so directories always
+		// end with '/'
+		if !strings.HasSuffix(t, "/") {
+			t = t + "/"
+		}
+	} else {
+		isDir = strings.HasSuffix(t, string(sep))
+	}
+
 	dirs := strings.Split(t, string(sep))
-	isDir := strings.HasSuffix(t, string(sep))
+
+	// Git-attribute style matching can never match a directory
+	if w.gitattributes && isDir {
+		return dirs, false
+	}
 
 	// Match each directory token-wise, allowing each token to consume more
 	// than one directory in the case of the '**' pattern.
@@ -547,7 +587,7 @@ func (c *component) Consume(path []string, isDir bool) ([]string, bool) {
 		// Components can not match directories. If we were matching the
 		// last path in a tree structure, we can only match if it
 		// _wasn't_ a directory.
-		return path[1:], !isDir
+		return path[1:], true
 	}
 
 	return path[1:], true

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -638,6 +638,16 @@ var Cases = []*Case{
 		Opts:    []opt{Basename},
 		Match:   false,
 	},
+	{
+		Pattern: `anotherfile.txt/`,
+		Subject: `anotherfile.txt`,
+		Match:   false,
+	},
+	{
+		Pattern: `**/pdfkit.frameworks/pdfkit/**`,
+		Subject: `MyFolder/libs/pdfkit.frameworks/pdfkit`,
+		Match:   false,
+	},
 }
 
 func TestWildmatch(t *testing.T) {


### PR DESCRIPTION
Fixes #12 

This PR adds two cases to make sure the endings are correctly processed.

[The first one](https://github.com/git-lfs/wildmatch/compare/master...zkry:doublestar-ending-matching-file?expand=1#diff-dc64d839d1167e637dab55cc735efcc9R136) is when a blank token ends a file it should be processed as a blank component function. Before, by not adding anything, the search strings "file.txt" and "file.txt/" would be equivalent.

[The second one](https://github.com/git-lfs/wildmatch/compare/master...zkry:doublestar-ending-matching-file?expand=1#diff-dc64d839d1167e637dab55cc735efcc9R266) makes sure that a doublestar will fail if it is at the end and there are no more directories to match (similar to what the component does).

This will require some change coordinations with git-lfs as it depends on this mismatch.