### PR TITLE
Fix ** matches to explore multiple possible matches

### DIFF
--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -681,6 +681,31 @@ var Cases = []*Case{
 		Subject: `MyFolder/libs/pdfkit.frameworks/pdfkit`,
 		Match:   false,
 	},
+	{
+		Pattern: `**/stop/file.txt`,
+		Subject: `a/b/c/stop/d/e/f/stop/file.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `**/*/some-file.txt`,
+		Subject: `path/to/some-file.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `**/*a/**/*a/**/*a/here.txt`,
+		Subject: `dir1/dira/dir2/dir3/dira/dir4/dir5/dira/here.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `*/**/end.txt`,
+		Subject: `qwrty/doublestar/can/take/as/much/dirs/as/it/wants/end.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `**/a*/**/b*/**/done.txt`,
+		Subject: `adir/dir1/dir2/bdir/adir/dir3/dir4/done.txt`,
+		Match:   true,
+	},
 }
 
 func TestWildmatch(t *testing.T) {


### PR DESCRIPTION
fixes #14

Previously the doublestar token would match greedily as much as it could, so for example, the double star token of the pattern `**/*/file`, when applied to a directory string `a/b/c/file`, would greedily match all of `a/b/c/file` and not leave enough for the rest of the pattern (`*/file`). 

The solution implemented here changes the token interface so that the Consume method returns a slice of paths([]string) that the token could match. These results are added to a stack and iterated over until a solution is found. So in the above example, instead of just returning an empty slice of strings (because the `**` consumed everything), it would return the following slice:

```
[
  [""]
  ["file"]
  ["c" "file"]
  ["b" "c" "file"]
]
```

So now, the rest of the pattern (`file`) can match the second item returned.