### PR TITLE
Ensure that non-ASCII strings match themselves

### DIFF
--- a/wildmatch.go
+++ b/wildmatch.go
@@ -111,7 +111,7 @@ func slashEscape(p string) string {
 				i += 1
 			}
 		default:
-			pp += string(c)
+			pp += string([]byte{c})
 			i += 1
 		}
 	}

--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -238,6 +238,16 @@ var Cases = []*Case{
 		Match:   false,
 	},
 	{
+		Pattern: `*.txt`,
+		Subject: `你好-世界.txt`,
+		Match:   true,
+	},
+	{
+		Pattern: `你好-世界.txt`,
+		Subject: `你好-世界.txt`,
+		Match:   true,
+	},
+	{
 		Pattern: `foo*`,
 		Subject: `foobar`,
 		Match:   true,


### PR DESCRIPTION
In the wildmatch code, we escape the strings in a pattern by iterating over each byte and then appending the result of each iteration of the loop to a new string.  If the character is not part of an escape sequence, we append it by casting it to a string.

However, this does not produce the expected results.  When casting an integral value, such as a byte, to a string, the integral value is interpreted as a rune.  Consequently, each byte with value greater than 127 in the original string was being turned into a UTF-8 sequence corresponding to that byte's value in Latin-1.

Because a string which is overencoded does not match the original string, any attempt to have a non-ASCII string match itself would fail.  Solve this by taking our byte value and first creating a byte slice, and then casting that to a string.

For the curious, Google Translate reports that the string used in the tests is Chinese for "hello world".  Using a string that is not in Latin-1 is preferable to a Latin-1 string because it makes it less likely that we're getting things right by accident.

/cc @yunshan as reporter
Fixes git-lfs/git-lfs#3794.