### PR TITLE
Switch to GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build-go:
+    name: Default build
+    strategy:
+      matrix:
+        go: ['1.12.x', '1.13.x', '1.14.x']
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+    - run: script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-go: 1.11
-before_install:
-  - >
-    mkdir -p ~/src;
-    mv "$TRAVIS_BUILD_DIR" ~/src/wildmatch;
-    export TRAVIS_BUILD_DIR=~/src/wildmatch;
-notifications:
-  email: false

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+go test ./...


### PR DESCRIPTION
We're already using GitHub Actions for the main Git LFS codebase, so let's switch here as well. We introduce a script to running CI which is currently very simple but can be expanded in the future if need be. We run entirely on Ubuntu because there's very little that's OS specific in this module, and we support the same versions of Go that Git LFS does.