### PR TITLE
SECURITY.md: add link to main security policy doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+Please see
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/master/SECURITY.md)
+in the main Git LFS repository for information on how to report security
+vulnerabilities in this package.


### PR DESCRIPTION
Add a simple link to the main security report policy.