### PR TITLE
Improve matching of directories

### DIFF
--- a/wildmatch_test.go
+++ b/wildmatch_test.go
@@ -202,7 +202,7 @@ var Cases = []*Case{
 	{
 		Pattern: `**/bar/*`,
 		Subject: `deep/foo/bar/baz/`,
-		Match:   false,
+		Match:   true,
 	},
 	{
 		Pattern: `**/bar/**`,
@@ -218,6 +218,26 @@ var Cases = []*Case{
 		Pattern: `**/bar/**`,
 		Subject: `deep/foo/bar/`,
 		Match:   true,
+	},
+	{
+		Pattern: `**/bar/**`,
+		Subject: `deep/foo/bar`,
+		Match:   false,
+	},
+	{
+		Pattern: `**/bar/**/*`,
+		Subject: `deep/foo/bar/`,
+		Match:   true,
+	},
+	{
+		Pattern: `**/bar/**/*`,
+		Subject: `deep/foo/bar`,
+		Match:   false,
+	},
+	{
+		Pattern: `**/bar/**/*`,
+		Subject: `deep/bar/bar`,
+		Match:   false,
 	},
 	{
 		Pattern: `*/bar/**`,
@@ -651,6 +671,11 @@ var Cases = []*Case{
 		Match:   false,
 	},
 	{
+		Pattern: `path/`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Match:   false,
+	},
+	{
 		// GitAttribute-style matching directory.
 		// false becalse gitattribute never matches directories.
 		Pattern:   `anotherfile.txt/`,
@@ -689,6 +714,41 @@ var Cases = []*Case{
 	{
 		Pattern: `**/pdfkit.frameworks/pdfkit/**`,
 		Subject: `MyFolder/libs/pdfkit.frameworks/pdfkit`,
+		Match:   false,
+	},
+	{
+		Pattern:   `foo/`,
+		Subject:   `bar/baz/foo`,
+		MatchOpts: MatchOpts{IsDirectory: true},
+		Match:     true,
+	},
+	{
+		Pattern:   `foo/`,
+		Subject:   `foo`,
+		MatchOpts: MatchOpts{IsDirectory: true},
+		Match:     true,
+	},
+	{
+		Pattern:   `foo/`,
+		Subject:   `foo/`,
+		Match:     true,
+	},
+	{
+		Pattern: `path/`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Opts:    []opt{Contents},
+		Match:   true,
+	},
+	{
+		Pattern: `to/`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Opts:    []opt{Contents},
+		Match:   true,
+	},
+	{
+		Pattern: `nonexistent/`,
+		Subject: `path/to/some/intermediaries/to/file.txt`,
+		Opts:    []opt{Contents},
 		Match:   false,
 	},
 }


### PR DESCRIPTION
Git has two types of patterns: gitignore patterns and gitattributes patterns.  The former matches directories, and the latter does not.  In addition, the former treats a single unrooted directory as appearing anywhere in the path, and it also treats a directory as matching all of its contents recursively.

Let's improve our support for gitignore patterns by handling these unrooted directories, which we had not previously handled correctly.  We use a new type of pattern which works like a doubleStar, but serializes differently, to match the directory anywhere in the tree.

We also add an option to handle the contents behavior, in which we recursively match the contents of a directory.  We use a new type, trailingComponents, which works like doubleStar except for the serialization.

None of this behavior is enabled in gitattributes mode because none of that syntax is allowed there.

We add some additional tests and fix the response to a test which was not correct for our gitignore behavior, but which should not function correctly.
