### PR TITLE
go.mod: bump to version 2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/git-lfs/wildmatch
+module github.com/git-lfs/wildmatch/v2
+
+go 1.15


### PR DESCRIPTION
We need to bump the package import path to v2 since Go requires the module name to change when we bump the major version.