### PR TITLE
Upgrade CI workflow to latest Go and Actions versions and add monthly checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Default build
     strategy:
       matrix:
-        go: ['1.12.x', '1.13.x', '1.14.x']
+        go: ['1.18.x', '1.19.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
         go: ['1.18.x', '1.19.x']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-go@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: script/cibuild


### PR DESCRIPTION
We update our GitHub Actions CI workflow to use the latest supported Go versions and the latest versions of all Actions steps, and we schedule monthly checks by the GitHub Dependabot service of our workflows to ensure we continue using the latest versions of all Actions steps.

Thanks tp @jlosito for the suggestion to add Dependabot Actions checks in git-lfs/git-lfs#5228.