### PR TITLE
Add status badge and update default branch name in security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # wildmatch
 
+[![CI status][ci_badge]][ci_url]
+
+[ci_badge]: https://github.com/git-lfs/wildmatch/workflows/CI/badge.svg
+[ci_url]: https://github.com/git-lfs/wildmatch/actions?query=workflow%3ACI
+
 package `wildmatch` is a reimplementation of Git's `wildmatch.c`-style filepath pattern matching.
 
 For more information, see the [godoc][1].

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 Please see
-[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/master/SECURITY.md)
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/main/SECURITY.md)
 in the main Git LFS repository for information on how to report security
 vulnerabilities in this package.


### PR DESCRIPTION
We are now using GitHub Actions for CI, so we add a status badge for it to our `README`.

We also update our link to the Git LFS project's main security documentation in the `git-lfs/git-lfs` repository to use that repository's current default branch name of `main`.