### PR TITLE
Update Go versions to 1.25 and 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Default build
     strategy:
       matrix:
-        go: ['1.20.x', '1.21.x']
+        go: ['1.25.x', '1.26.x']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
Because we aim to build and test against only supported versions of Go, we upgrade our GitHub Actions CI workflows to test against Go versions 1.26 and 1.25.

Note that several older required CI jobs will not run for this PR, and the newer jobs should be marked as required after this PR is merged.